### PR TITLE
Clear error flag in glGetError

### DIFF
--- a/source/vitaGL.c
+++ b/source/vitaGL.c
@@ -1395,7 +1395,9 @@ void vglWaitVblankStart(GLboolean enable){
 // openGL implementation
 
 GLenum glGetError(void){
-	return error;
+	GLenum ret = error;
+	error = GL_NO_ERROR;
+	return ret;
 }
 
 void glClear(GLbitfield mask){


### PR DESCRIPTION
glGetError is [supposed to clear the error flag after reading it](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetError.xhtml).
Needed by Xash3D.