### PR TITLE
Fixed sample compilation (again)

### DIFF
--- a/samples/sample1/Makefile
+++ b/samples/sample1/Makefile
@@ -17,7 +17,7 @@ OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 CXX      = $(PREFIX)-g++
-CFLAGS  = -fno-lto -g -Wl,-q -O3
+CFLAGS  = -g -Wl,-q -O3
 CXXFLAGS  = $(CFLAGS) -fno-exceptions -std=gnu++11 -fpermissive
 ASFLAGS = $(CFLAGS)
 

--- a/samples/sample1/main.c
+++ b/samples/sample1/main.c
@@ -4,7 +4,7 @@
 #include <vita2d.h>
 
 GLint nofcolors = 4;
-GLenum texture_format = GL_VITA2D_TEXTURE;
+GLenum texture_format = GL_ACTIVE_TEXTURE;
 GLuint texture = 0;
 
 int main(){

--- a/samples/sample3/Makefile
+++ b/samples/sample3/Makefile
@@ -15,7 +15,7 @@ OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 CXX      = $(PREFIX)-g++
-CFLAGS  = -fno-lto -g -Wl,-q -O3
+CFLAGS  = -g -Wl,-q -O3
 CXXFLAGS  = $(CFLAGS) -fno-exceptions -std=gnu++11 -fpermissive
 ASFLAGS = $(CFLAGS)
 

--- a/samples/sample3/main.c
+++ b/samples/sample3/main.c
@@ -3,7 +3,7 @@
 #include <vitaGL.h>
 
 GLint nofcolors = 4;
-GLenum texture_format = GL_VITA2D_TEXTURE;
+GLenum texture_format = GL_ACTIVE_TEXTURE;
 GLuint texture = 0;
 
 int main(){

--- a/samples/sample4/Makefile
+++ b/samples/sample4/Makefile
@@ -14,7 +14,7 @@ OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 CXX      = $(PREFIX)-g++
-CFLAGS  = -fno-lto -g -Wl,-q -O3
+CFLAGS  = -g -Wl,-q -O3
 CXXFLAGS  = $(CFLAGS) -fno-exceptions -std=gnu++11 -fpermissive
 ASFLAGS = $(CFLAGS)
 

--- a/samples/sample5/Makefile
+++ b/samples/sample5/Makefile
@@ -14,7 +14,7 @@ OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 CXX      = $(PREFIX)-g++
-CFLAGS  = -fno-lto -g -Wl,-q -O3
+CFLAGS  = -g -Wl,-q -O3
 CXXFLAGS  = $(CFLAGS) -fno-exceptions -std=gnu++11 -fpermissive
 ASFLAGS = $(CFLAGS)
 

--- a/samples/sample6/Makefile
+++ b/samples/sample6/Makefile
@@ -14,7 +14,7 @@ OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 CXX      = $(PREFIX)-g++
-CFLAGS  = -fno-lto -g -Wl,-q -O3
+CFLAGS  = -g -Wl,-q -O3
 CXXFLAGS  = $(CFLAGS) -fno-exceptions -std=gnu++11 -fpermissive
 ASFLAGS = $(CFLAGS)
 


### PR DESCRIPTION
samples won't link properly when using -fno-lto  (at least for me. it used to work fine, though.)

also issue #27 