### PR TITLE
Ensure vglSetupRuntimeShaderCompiler will only build with HAVE_SHARK.

### DIFF
--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -157,12 +157,14 @@ void shark_log_cb(const char *msg, shark_log_level msg_level, int line) {
  * - IMPLEMENTATION STARTS HERE -
  * ------------------------------
  */
+#ifdef HAVE_SHARK
 void vglSetupRuntimeShaderCompiler(shark_opt opt_level, int32_t use_fastmath, int32_t use_fastprecision, int32_t use_fastint) {
 	compiler_opts = opt_level;
 	compiler_fastmath = use_fastmath;
 	compiler_fastprecision = use_fastprecision;
 	compiler_fastint = use_fastint;
 }
+#endif
  
 void vglEnableRuntimeShaderCompiler(GLboolean usage) {
 	use_shark = usage;

--- a/source/textures.c
+++ b/source/textures.c
@@ -773,7 +773,7 @@ void glTexParameterf(GLenum target, GLenum pname, GLfloat param) {
 			else if (param == GL_MIRRORED_REPEAT)
 				tex_unit->v_mode = SCE_GXM_TEXTURE_ADDR_MIRROR; // Mirror
 			else if (param == GL_MIRROR_CLAMP_EXT)
-				tex_unit->u_mode = SCE_GXM_TEXTURE_ADDR_MIRROR_CLAMP; // Mirror Clamp
+				tex_unit->v_mode = SCE_GXM_TEXTURE_ADDR_MIRROR_CLAMP; // Mirror Clamp
 			sceGxmTextureSetVAddrMode(&tex->gxm_tex, tex_unit->v_mode);
 			break;
 		case GL_TEXTURE_LOD_BIAS: // Distant LOD bias


### PR DESCRIPTION
Also, fixed an error in glTexParameterf that was not resolved in commit 0ac2793.