### PR TITLE
Add non power-of-two compressed texture support, and add mipmap support for compressed textures.

### DIFF
--- a/source/textures.c
+++ b/source/textures.c
@@ -309,13 +309,15 @@ void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei widt
 		// Allocating texture/mipmaps depending on user call
 		tex->type = internalFormat;
 		tex->write_cb = write_cb;
-		if (level == 0)
-			if (tex->write_cb)
+
+		if (tex->write_cb) {
+			if (level == 0)
 				gpu_alloc_texture(width, height, tex_format, data, tex, data_bpp, read_cb, write_cb, fast_store);
 			else
-				gpu_alloc_compressed_texture(width, height, tex_format, 0, data, tex, data_bpp, read_cb);
-		else
-			gpu_alloc_mipmaps(level, tex);
+				gpu_alloc_mipmaps(level, tex);
+		} else
+			gpu_alloc_compressed_texture(level, width, height, tex_format, 0, data, tex, data_bpp, read_cb);
+
 
 		// Setting texture parameters
 		sceGxmTextureSetUAddrMode(&tex->gxm_tex, tex->u_mode);
@@ -581,7 +583,7 @@ void glCompressedTexImage2D(GLenum target, GLint level, GLenum internalFormat, G
 
 		// Allocating texture/mipmaps depending on user call
 		tex->type = internalFormat;
-		gpu_alloc_compressed_texture(width, height, tex_format, imageSize, data, tex, 0, NULL);
+		gpu_alloc_compressed_texture(level, width, height, tex_format, imageSize, data, tex, 0, NULL);
 
 		// Setting texture parameters
 		sceGxmTextureSetUAddrMode(&tex->gxm_tex, tex->u_mode);

--- a/source/textures.c
+++ b/source/textures.c
@@ -528,11 +528,6 @@ void glCompressedTexImage2D(GLenum target, GLint level, GLenum internalFormat, G
 		SET_GL_ERROR(GL_INVALID_VALUE)
 	}
 
-	// Checking if texture dimensions are not a power of two
-	if (((width & (width - 1)) != 0) || ((height & (height - 1)) != 0)) {
-		SET_GL_ERROR(GL_INVALID_VALUE)
-	}
-
 	// Ensure imageSize isn't zero.
 	if (imageSize == 0) {
 		SET_GL_ERROR(GL_INVALID_VALUE)
@@ -541,7 +536,7 @@ void glCompressedTexImage2D(GLenum target, GLint level, GLenum internalFormat, G
 
 	switch (target) {
 	case GL_TEXTURE_2D:
-		// Detecting proper write callback and texture format
+		// Detecting proper texture format
 		switch (internalFormat) {
 		case GL_COMPRESSED_RGB_S3TC_DXT1_EXT:
 		case GL_COMPRESSED_RGBA_S3TC_DXT1_EXT:

--- a/source/utils/gpu_utils.c
+++ b/source/utils/gpu_utils.c
@@ -24,12 +24,6 @@
 #include "../shared.h"
 #include "stb_dxt.h"
 
-#ifndef MIN
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#define MAX(a, b) (((a) < (b)) ? (b) : (a))
-#define CEIL(a) ((a - (int)a) == 0 ? (int)a : (int)a + 1)
-#endif
-
 // VRAM usage setting
 uint8_t use_vram = 0;
 uint8_t use_vram_for_usse = 0;
@@ -80,10 +74,10 @@ int gpu_get_mipchain_size(int level, int width, int height, SceGxmTextureFormat 
 			break;
 		case SCE_GXM_TEXTURE_FORMAT_UBC1_1BGR:
 		case SCE_GXM_TEXTURE_FORMAT_UBC1_ABGR:
-			size += (width * height) / 2;
+			size += CEIL(width / 4) * CEIL(height / 4) * 8;
 			break;
 		case SCE_GXM_TEXTURE_FORMAT_UBC3_ABGR:
-			size += width * height;
+			size += CEIL(width / 4) * CEIL(height / 4) * 16;
 			break;
 		}
 		width *= 2;
@@ -132,7 +126,9 @@ static void extract_block(const uint8_t *src, int width, uint8_t *block) {
 
 static void dxt_compress(uint8_t *dst, uint8_t *src, int w, int h, int aligned_width, int aligned_height, int isdxt5) {
 	uint8_t block[64];
-	uint32_t num_blocks = (aligned_width * aligned_height) / 16;
+
+	int s = MAX(aligned_width, aligned_height);
+	uint32_t num_blocks = (s * s) / 16;
 	uint64_t d, offs_x, offs_y;
 	for (d = 0; d < num_blocks; d++) {
 		d2xy_morton(d, &offs_x, &offs_y);
@@ -156,7 +152,8 @@ static void dxt_compress(uint8_t *dst, uint8_t *src, int w, int h, int aligned_w
 static void swizzle_compressed_texture(uint8_t *dst, uint8_t *src, int w, int h, int aligned_width, int aligned_height, int isdxt5, int ispvrt2bpp) {
 	int blocksize = isdxt5 ? 16 : 8;
 
-	uint32_t num_blocks = (aligned_width * aligned_height) / (ispvrt2bpp ? 32 : 16);
+	int s = MAX(aligned_width, aligned_height);
+	uint32_t num_blocks = (s * s) / (ispvrt2bpp ? 32 : 16);
 	uint64_t d, offs_x, offs_y;
 	for (d = 0; d < num_blocks; d++) {
 		d2xy_morton(d, &offs_x, &offs_y);
@@ -164,45 +161,49 @@ static void swizzle_compressed_texture(uint8_t *dst, uint8_t *src, int w, int h,
 		if (offs_x * 4 >= h) {
 			// If the block coord is smaller than the Po2 aligned dimension, skip forward one block.
 			if (offs_x * 4 < aligned_height)
-				dst += isdxt5 ? 16 : 8;
+				dst += blocksize;
 			continue;
 		}
 
 		if (offs_y * (ispvrt2bpp ? 8 : 4) >= w) {
 			if (offs_y * (ispvrt2bpp ? 8 : 4) < aligned_width)
-				dst += isdxt5 ? 16 : 8;
+				dst += blocksize;
 			continue;
 		}
 
 		memcpy(dst, src + offs_y * blocksize + offs_x * (w / (ispvrt2bpp ? 8 : 4)) * blocksize, blocksize);
-		dst += isdxt5 ? 16 : 8;
+		dst += blocksize;
 	}
 }
 
 void swizzle_compressed_texture_region(void *dst, const void *src, int tex_width, int tex_height, int region_x, int region_y, int region_width, int region_height, int isdxt5, int ispvrt2bpp) {
 	int blocksize = isdxt5 ? 16 : 8;
-	void *dest;
 
-	uint32_t num_blocks = (tex_width * tex_height) / (ispvrt2bpp ? 32 : 16);
+	int s = MAX(tex_width, tex_height);
+	uint32_t num_blocks = (s * s) / (ispvrt2bpp ? 32 : 16);
 	uint64_t d, offs_x, offs_y;
+	uint64_t dst_x, dst_y;
 	for (d = 0; d < num_blocks; d++) {
 		d2xy_morton(d, &offs_x, &offs_y);
 		// If the block coords exceed input texture dimensions.
-		if ((offs_x * 4 >= region_height) || (offs_x * 4 < region_y)) {
+		if ((offs_x * 4 >= region_height + region_y) || (offs_x * 4 < region_y)) {
 			// If the block coord is smaller than the Po2 aligned dimension, skip forward one block.
 			if (offs_x * 4 < tex_height)
-				dst += isdxt5 ? 16 : 8;
+				dst += blocksize;
 			continue;
 		}
 
-		if ((offs_y * (ispvrt2bpp ? 8 : 4) >= region_width) || (offs_y * (ispvrt2bpp ? 8 : 4) < region_x)) {
+		if ((offs_y * (ispvrt2bpp ? 8 : 4) >= region_width + region_x) || (offs_y * (ispvrt2bpp ? 8 : 4) < region_x)) {
 			if (offs_y * (ispvrt2bpp ? 8 : 4) < tex_width)
-				dst += isdxt5 ? 16 : 8;
+				dst += blocksize;
 			continue;
 		}
 
-		memcpy(dst, src + (offs_y - region_y) * blocksize + (offs_x - region_x) * (region_width / (ispvrt2bpp ? 8 : 4)) * blocksize, blocksize);
-		dst += isdxt5 ? 16 : 8;
+		dst_x = offs_x - (region_y / 4);
+		dst_y = offs_y - (region_x / (ispvrt2bpp ? 8 : 4));
+
+		memcpy(dst, src + dst_y * blocksize + dst_x * (region_width / (ispvrt2bpp ? 8 : 4)) * blocksize, blocksize);
+		dst += blocksize;
 	}
 }
 
@@ -478,37 +479,16 @@ void gpu_alloc_compressed_texture(uint32_t mip_level, uint32_t w, uint32_t h, Sc
 		break;
 	case SCE_GXM_TEXTURE_FORMAT_UBC1_1BGR:
 	case SCE_GXM_TEXTURE_FORMAT_UBC1_ABGR:
-		expected_tex_size = (w * h) / 2;
+		expected_tex_size = CEIL(w / 4) * CEIL(h / 4) * 8;
 		break;
 	case SCE_GXM_TEXTURE_FORMAT_UBC3_ABGR:
-		expected_tex_size = w * h;
+		expected_tex_size = CEIL(w / 4) * CEIL(h / 4) * 16;
 		break;
 	}
 
 	// Check the given texture data size.
 	if (image_size != 0 && image_size != expected_tex_size) {
 		SET_GL_ERROR(GL_INVALID_VALUE)
-	}
-
-	// Ensure the texture's width and height are block aligned.
-	switch (format) {
-	case SCE_GXM_TEXTURE_FORMAT_PVRT4BPP_1BGR:
-	case SCE_GXM_TEXTURE_FORMAT_PVRT4BPP_ABGR:
-	case SCE_GXM_TEXTURE_FORMAT_PVRTII4BPP_ABGR:
-	case SCE_GXM_TEXTURE_FORMAT_UBC1_1BGR:
-	case SCE_GXM_TEXTURE_FORMAT_UBC1_ABGR:
-	case SCE_GXM_TEXTURE_FORMAT_UBC3_ABGR:
-		if ((w % 4 != 0) || (h % 4 != 0)) {
-			SET_GL_ERROR(GL_INVALID_VALUE)
-		}
-		break;
-	case SCE_GXM_TEXTURE_FORMAT_PVRT2BPP_1BGR:
-	case SCE_GXM_TEXTURE_FORMAT_PVRT2BPP_ABGR:
-	case SCE_GXM_TEXTURE_FORMAT_PVRTII2BPP_ABGR:
-		if ((w % 8 != 0) || (h % 4 != 0)) {
-			SET_GL_ERROR(GL_INVALID_VALUE)
-		}
-		break;
 	}
 #endif
 

--- a/source/utils/gpu_utils.c
+++ b/source/utils/gpu_utils.c
@@ -339,7 +339,10 @@ void gpu_alloc_texture(uint32_t w, uint32_t h, SceGxmTextureFormat format, const
 			memset(texture_data, 0, tex_size);
 
 		// Initializing texture and validating it
-		sceGxmTextureInitLinear(&tex->gxm_tex, texture_data, format, w, h, 0);
+		if (sceGxmTextureInitLinear(&tex->gxm_tex, texture_data, format, w, h, 0) < 0) {
+			SET_GL_ERROR(GL_INVALID_VALUE)
+		}
+
 		if ((format & 0x9f000000U) == SCE_GXM_TEXTURE_BASE_FORMAT_P8)
 			tex->palette_UID = 1;
 		else
@@ -472,7 +475,10 @@ void gpu_alloc_compressed_texture(uint32_t w, uint32_t h, SceGxmTextureFormat fo
 			memset(texture_data, 0, tex_size);
 
 		// Initializing texture and validating it
-		sceGxmTextureInitSwizzledArbitrary(&tex->gxm_tex, texture_data, format, w, h, 0);
+		if (sceGxmTextureInitSwizzledArbitrary(&tex->gxm_tex, texture_data, format, w, h, 0) < 0) {
+			SET_GL_ERROR(GL_INVALID_VALUE)
+		}
+		
 		tex->palette_UID = 0;
 		tex->valid = 1;
 		tex->data = texture_data;

--- a/source/utils/gpu_utils.h
+++ b/source/utils/gpu_utils.h
@@ -28,6 +28,9 @@
 
 // Align a value to the requested alignment
 #define ALIGN(x, a) (((x) + ((a)-1)) & ~((a)-1))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a, b) (((a) < (b)) ? (b) : (a))
+#define CEIL(a) ((a - (int)a) == 0 ? (int)a : (int)a + 1)
 
 // Texture object struct
 typedef struct texture {

--- a/source/utils/gpu_utils.h
+++ b/source/utils/gpu_utils.h
@@ -91,7 +91,7 @@ int tex_format_to_bytespp(SceGxmTextureFormat format);
 void gpu_alloc_texture(uint32_t w, uint32_t h, SceGxmTextureFormat format, const void *data, texture *tex, uint8_t src_bpp, uint32_t (*read_cb)(void *), void (*write_cb)(void *, uint32_t), uint8_t fast_store);
 
 // Alloc a compresseed texture
-void gpu_alloc_compressed_texture(uint32_t w, uint32_t h, SceGxmTextureFormat format, uint32_t image_size, const void *data, texture *tex, uint8_t src_bpp, uint32_t (*read_cb)(void *));
+void gpu_alloc_compressed_texture(uint32_t mipLevel, uint32_t w, uint32_t h, SceGxmTextureFormat format, uint32_t image_size, const void *data, texture *tex, uint8_t src_bpp, uint32_t (*read_cb)(void *));
 
 // Dealloc a texture
 void gpu_free_texture(texture *tex);

--- a/source/utils/gpu_utils.h
+++ b/source/utils/gpu_utils.h
@@ -54,6 +54,11 @@ typedef struct palette {
 	vglMemType type;
 } palette;
 
+// Utility Function.
+uint32_t nearest_po2(uint32_t val); 
+// Swizzle and copy texture region.
+void swizzle_compressed_texture_region(void *dst, const void *src, int tex_width, int tex_height, int region_x, int region_y, int region_width, int region_height, int isdxt5, int ispvrt2bpp);
+
 // Alloc a generic memblock into sceGxm mapped memory
 void *gpu_alloc_mapped(size_t size, vglMemType *type);
 
@@ -104,5 +109,14 @@ void gpu_free_palette(palette *pal);
 
 // Generate mipmaps for a given texture
 void gpu_alloc_mipmaps(int level, texture *tex);
+
+// Get the size of a mipchain with the last mip width and height
+int gpu_get_mipchain_size(int level, int width, int height, SceGxmTextureFormat format);
+
+// Get the offset of a specified mip level, of a given width and height.
+int gpu_get_mip_offset(int level, int width, int height, SceGxmTextureFormat format);
+
+// Get dimensions of a mip level, given top level dimensions.
+void gpu_get_mip_size(int level, int width, int height, int *mip_width, int *mip_height);
 
 #endif

--- a/source/utils/gpu_utils.h
+++ b/source/utils/gpu_utils.h
@@ -49,6 +49,7 @@ typedef struct texture {
 	SceGxmTextureAddrMode v_mode;
 	SceGxmTextureMipFilter mip_filter;
 	uint32_t lod_bias;
+	uint8_t generate_mipmap;
 } texture;
 
 // Palette object struct
@@ -112,6 +113,9 @@ void gpu_free_palette(palette *pal);
 
 // Generate mipmaps for a given texture
 void gpu_alloc_mipmaps(int level, texture *tex);
+
+// Generate mipmaps for a compressed texture
+void gpu_alloc_compressed_mipmaps(texture *tex, int isdxt5, int gl_format, void *data);
 
 // Get the size of a mipchain with the last mip width and height
 int gpu_get_mipchain_size(int level, int width, int height, SceGxmTextureFormat format);

--- a/source/vitaGL.h
+++ b/source/vitaGL.h
@@ -202,6 +202,7 @@ extern "C" {
 #define GL_BGRA                               0x80E1
 #define GL_COLOR_INDEX8_EXT                   0x80E5
 #define GL_CLAMP_TO_EDGE                      0x812F
+#define GL_GENERATE_MIPMAP                    0x8191
 #define GL_RG                                 0x8227
 #define GL_UNSIGNED_SHORT_5_6_5               0x8363
 #define GL_MIRRORED_REPEAT                    0x8370

--- a/source/vitaGL.h
+++ b/source/vitaGL.h
@@ -322,6 +322,7 @@ void glColorPointer(GLint size, GLenum type, GLsizei stride, const GLvoid *point
 void glColorTable(GLenum target, GLenum internalformat, GLsizei width, GLenum format, GLenum type, const GLvoid *data);
 void glCompileShader(GLuint shader);
 void glCompressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void *data); // Mipmap levels are ignored currently
+void glCompressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, const void *data);
 GLuint glCreateProgram(void);
 GLuint glCreateShader(GLenum shaderType);
 void glCullFace(GLenum mode);


### PR DESCRIPTION
Also added some documentation and error checking. Switched RGB DXT1 to using recently added RGB1 BC1 from vitasdk, rather than RGBA BC1.