### PR TITLE
Add GL_EXT_bgra to the list of supported extensions

### DIFF
--- a/source/get_info.c
+++ b/source/get_info.c
@@ -41,6 +41,7 @@ static GLubyte *extensions[] = {
 	"GL_ARB_texture_compression",
 	"GL_ARB_vertex_buffer_object",
 	"GL_EXT_abgr",
+	"GL_EXT_bgra",
 	"GL_EXT_color_buffer_half_float",
 	"GL_EXT_draw_instanced",
 	"GL_EXT_framebuffer_object",


### PR DESCRIPTION
The format is already supported by vitaGL, just need to expose the extension in case the application is using a really old version of OpenGL where the format is still considered an extension.