### PR TITLE
Hide xxhash symbols

### DIFF
--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -27,9 +27,11 @@
 #include "utils/glsl_utils.h"
 #include "utils/shacccg_paramquery.h"
 #if defined(HAVE_SHADER_CACHE) || defined(HAVE_TEX_CACHE)
+#pragma GCC visibility push(hidden)
 #define XXH_STATIC_LINKING_ONLY
 #define XXH_IMPLEMENTATION
 #include "utils/xxhash_utils.h"
+#pragma GCC visibility pop
 #ifdef HAVE_SHADER_CACHE
 char vgl_shader_cache_path[256];
 #endif


### PR DESCRIPTION
Attempt to hide xxhash symbols and prevent multiple definition when a project uses both vitaGL (with texture or shader caches) and xxhash.

This issue can be found when building Flycast: https://github.com/scribam/flycast/actions/runs/9207514634/job/25327736382#step:7:1119
