### PR TITLE
Fix GL_UNPACK_ROW_LENGTH in glTexSubImage2D

### DIFF
--- a/source/textures.c
+++ b/source/textures.c
@@ -1188,7 +1188,7 @@ static inline __attribute__((always_inline)) void _glTexSubImage2D(texture *tex,
 					ptr += bpp;
 				}
 				if (unpack_row_len) {
-					data = (uint8_t *)pixels + unpack_row_len * bpp;
+					data = (uint8_t *)pixels + unpack_row_len * data_bpp;
 					pixels = data;
 				}
 				ptr = ptr_line + stride;


### PR DESCRIPTION
I think the stride should be set from `data_bpp` here, not `bpp`. This at least makes textures work in Bugdom.