### PR TITLE
Memory safety fixes

### DIFF
--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -646,7 +646,8 @@ static inline __attribute__((always_inline)) void compile_shader(shader *s, GLbo
 			} else if (sceShaccCgGetParameterClass(param) == SCE_SHACCCG_PARAMETERCLASS_UNIFORMBLOCK) {
 				block_uniform *b = (block_uniform *)vglMalloc(sizeof(block_uniform));
 				b->idx = sceShaccCgGetParameterBufferIndex(param);
-				strcpy(b->name, sceShaccCgGetParameterName(param));
+				strncpy(b->name, sceShaccCgGetParameterName(param), sizeof(b->name)-1);
+				b->name[sizeof(b->name)-1] = 0;
 				b->chain = s->unif_blk;
 				s->unif_blk = b;
 			}
@@ -1693,6 +1694,7 @@ void glGetShaderSource(GLuint handle, GLsizei bufSize, GLsizei *length, GLchar *
 			src_len = bufSize - 1;
 		strncpy(source, s->source, src_len);
 		size = src_len;
+		source[size] = 0;
 	}
 	if (length)
 		*length = size;
@@ -1702,7 +1704,7 @@ void glShaderSource(GLuint handle, GLsizei count, const GLchar *const *string, c
 	THREAD_SAFE()
 
 #ifndef SKIP_ERROR_HANDLING
-	if (count < 0) {
+	if (count < 0 || count > 32) {
 		SET_GL_ERROR(GL_INVALID_VALUE)
 	}
 #endif
@@ -2474,7 +2476,7 @@ GLint glGetUniformLocation(GLuint prog, const GLchar *name) {
 	char tmp[64];
 	char *start = strstr(name, "[");
 	if (start) {
-		strcpy(tmp, name);
+		strncpy(tmp, name, sizeof(tmp)-1);
 		start = tmp + (start - name);
 		name = tmp;
 		char *end = strstr(start + 1, "]");
@@ -3241,7 +3243,9 @@ void glBindAttribLocation(GLuint prog, GLuint index, const GLchar *name) {
 		if (!p->glsl_attr_map)
 			p->glsl_attr_map = vglMalloc(sizeof(attr_mapping) * VERTEX_ATTRIBS_NUM);
 		p->glsl_attr_map[p->num_glsl_attr].idx = index;
-		strcpy(p->glsl_attr_map[p->num_glsl_attr++].name, name);
+		strncpy(p->glsl_attr_map[p->num_glsl_attr].name, name, sizeof(p->glsl_attr_map[p->num_glsl_attr].name)-1);
+		p->glsl_attr_map[p->num_glsl_attr].name[sizeof(p->glsl_attr_map[p->num_glsl_attr].name)-1] = 0;
+		p->num_glsl_attr++;
 		return;
 	}
 
@@ -3304,12 +3308,14 @@ void glGetActiveAttrib(GLuint prog, GLuint index, GLsizei bufSize, GLsizei *leng
 	}
 
 	// Copying attribute name
-	const char *pname = sceGxmProgramParameterGetName(param);
-	bufSize = min(strlen(pname), bufSize - 1);
-	if (length)
-		*length = bufSize;
-	strncpy(name, pname, bufSize);
-	name[bufSize] = 0;
+	if (bufSize > 0) {
+		const char *pname = sceGxmProgramParameterGetName(param);
+		bufSize = min(strlen(pname), bufSize - 1);
+		if (length)
+			*length = bufSize;
+		strncpy(name, pname, bufSize);
+		name[bufSize] = 0;
+	}
 
 	*type = gxm_attr_type_to_gl(sceGxmProgramParameterGetComponentCount(param), sceGxmProgramParameterGetArraySize(param));
 	*size = 1;
@@ -3371,16 +3377,18 @@ void glGetActiveUniform(GLuint prog, GLuint index, GLsizei bufSize, GLsizei *len
 		pname = "texture";
 	else if (!strcmp(pname, "Vgl_tex"))
 		pname = "Texture";
-	else if (!strcmp(name, "_matrix"))
-		name = "matrix";
-	else if (!strcmp(name, "_sampler"))
-		name = "sampler";
+	else if (!strcmp(pname, "_matrix"))
+		pname = "matrix";
+	else if (!strcmp(pname, "_sampler"))
+		pname = "sampler";
 
-	bufSize = min(strlen(pname), bufSize - 1);
-	if (length)
-		*length = bufSize;
-	strncpy(name, pname, bufSize);
-	name[bufSize] = 0;
+	if (bufSize > 0) {
+		bufSize = min(strlen(pname), bufSize - 1);
+		if (length)
+			*length = bufSize;
+		strncpy(name, pname, bufSize);
+		name[bufSize] = 0;
+	}
 }
 
 /*
@@ -3570,7 +3578,8 @@ void vglAddSemanticBinding(const GLchar *const *varying, GLint index, GLenum typ
 		return;
 	}			
 #endif
-	strcpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying);
+	strncpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying, sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1);
+	glsl_custom_bindings[glsl_custom_bindings_num].name[sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1] = 0;
 	glsl_custom_bindings[glsl_custom_bindings_num].idx = index;
 	glsl_custom_bindings[glsl_custom_bindings_num].type = type;
 	glsl_custom_bindings[glsl_custom_bindings_num++].ref_idx = glsl_current_ref_idx;
@@ -3585,7 +3594,8 @@ void vglAddSemanticBindingHint(const GLchar *const *varying, GLenum type) {
 		return;
 	}			
 #endif
-	strcpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying);
+	strncpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying, sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1);
+	glsl_custom_bindings[glsl_custom_bindings_num].name[sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1] = 0;
 	glsl_custom_bindings[glsl_custom_bindings_num].idx = -1;
 	glsl_custom_bindings[glsl_custom_bindings_num].type = type;
 	glsl_custom_bindings[glsl_custom_bindings_num++].ref_idx = glsl_current_ref_idx;

--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -1693,7 +1693,6 @@ void glGetShaderSource(GLuint handle, GLsizei bufSize, GLsizei *length, GLchar *
 			src_len = bufSize - 1;
 		strncpy(source, s->source, src_len);
 		size = src_len;
-		source[size] = 0;
 	}
 	if (length)
 		*length = size;

--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -3366,6 +3366,11 @@ void glGetActiveUniform(GLuint prog, GLuint index, GLsizei bufSize, GLsizei *len
 	}
 	
 	// Copying uniform name
+	if (bufSize == 0) {
+		if (length)
+			*length = 0;
+		return;
+	}
 	// texture, sampler and matrix are reserved keywords in CG but are not in GLSL
 	if (!strcmp(pname, "vgl_tex"))
 		pname = "texture";

--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -646,8 +646,7 @@ static inline __attribute__((always_inline)) void compile_shader(shader *s, GLbo
 			} else if (sceShaccCgGetParameterClass(param) == SCE_SHACCCG_PARAMETERCLASS_UNIFORMBLOCK) {
 				block_uniform *b = (block_uniform *)vglMalloc(sizeof(block_uniform));
 				b->idx = sceShaccCgGetParameterBufferIndex(param);
-				strncpy(b->name, sceShaccCgGetParameterName(param), sizeof(b->name)-1);
-				b->name[sizeof(b->name)-1] = 0;
+				strcpy(b->name, sceShaccCgGetParameterName(param));
 				b->chain = s->unif_blk;
 				s->unif_blk = b;
 			}
@@ -2476,7 +2475,7 @@ GLint glGetUniformLocation(GLuint prog, const GLchar *name) {
 	char tmp[64];
 	char *start = strstr(name, "[");
 	if (start) {
-		strncpy(tmp, name, sizeof(tmp)-1);
+		strcpy(tmp, name);
 		start = tmp + (start - name);
 		name = tmp;
 		char *end = strstr(start + 1, "]");
@@ -3243,9 +3242,7 @@ void glBindAttribLocation(GLuint prog, GLuint index, const GLchar *name) {
 		if (!p->glsl_attr_map)
 			p->glsl_attr_map = vglMalloc(sizeof(attr_mapping) * VERTEX_ATTRIBS_NUM);
 		p->glsl_attr_map[p->num_glsl_attr].idx = index;
-		strncpy(p->glsl_attr_map[p->num_glsl_attr].name, name, sizeof(p->glsl_attr_map[p->num_glsl_attr].name)-1);
-		p->glsl_attr_map[p->num_glsl_attr].name[sizeof(p->glsl_attr_map[p->num_glsl_attr].name)-1] = 0;
-		p->num_glsl_attr++;
+		strcpy(p->glsl_attr_map[p->num_glsl_attr++].name, name);
 		return;
 	}
 
@@ -3308,14 +3305,12 @@ void glGetActiveAttrib(GLuint prog, GLuint index, GLsizei bufSize, GLsizei *leng
 	}
 
 	// Copying attribute name
-	if (bufSize > 0) {
-		const char *pname = sceGxmProgramParameterGetName(param);
-		bufSize = min(strlen(pname), bufSize - 1);
-		if (length)
-			*length = bufSize;
-		strncpy(name, pname, bufSize);
-		name[bufSize] = 0;
-	}
+	const char *pname = sceGxmProgramParameterGetName(param);
+	bufSize = min(strlen(pname), bufSize - 1);
+	if (length)
+		*length = bufSize;
+	strncpy(name, pname, bufSize);
+	name[bufSize] = 0;
 
 	*type = gxm_attr_type_to_gl(sceGxmProgramParameterGetComponentCount(param), sceGxmProgramParameterGetArraySize(param));
 	*size = 1;
@@ -3578,8 +3573,7 @@ void vglAddSemanticBinding(const GLchar *const *varying, GLint index, GLenum typ
 		return;
 	}			
 #endif
-	strncpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying, sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1);
-	glsl_custom_bindings[glsl_custom_bindings_num].name[sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1] = 0;
+	strcpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying);
 	glsl_custom_bindings[glsl_custom_bindings_num].idx = index;
 	glsl_custom_bindings[glsl_custom_bindings_num].type = type;
 	glsl_custom_bindings[glsl_custom_bindings_num++].ref_idx = glsl_current_ref_idx;
@@ -3594,8 +3588,7 @@ void vglAddSemanticBindingHint(const GLchar *const *varying, GLenum type) {
 		return;
 	}			
 #endif
-	strncpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying, sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1);
-	glsl_custom_bindings[glsl_custom_bindings_num].name[sizeof(glsl_custom_bindings[glsl_custom_bindings_num].name)-1] = 0;
+	strcpy(glsl_custom_bindings[glsl_custom_bindings_num].name, varying);
 	glsl_custom_bindings[glsl_custom_bindings_num].idx = -1;
 	glsl_custom_bindings[glsl_custom_bindings_num].type = type;
 	glsl_custom_bindings[glsl_custom_bindings_num++].ref_idx = glsl_current_ref_idx;

--- a/source/custom_shaders.c
+++ b/source/custom_shaders.c
@@ -3376,13 +3376,11 @@ void glGetActiveUniform(GLuint prog, GLuint index, GLsizei bufSize, GLsizei *len
 	else if (!strcmp(pname, "_sampler"))
 		pname = "sampler";
 
-	if (bufSize > 0) {
-		bufSize = min(strlen(pname), bufSize - 1);
-		if (length)
-			*length = bufSize;
-		strncpy(name, pname, bufSize);
-		name[bufSize] = 0;
-	}
+	bufSize = min(strlen(pname), bufSize - 1);
+	if (length)
+		*length = bufSize;
+	strncpy(name, pname, bufSize);
+	name[bufSize] = 0;
 }
 
 /*

--- a/source/utils/glsl_utils.c
+++ b/source/utils/glsl_utils.c
@@ -1086,8 +1086,7 @@ void glsl_translator_process(shader *s) {
 	vgl_log("%s:%d %s: GLSL translation input:\n\n%s\n\n", __FILE__, __LINE__, __func__, input);
 #endif
 
-	char *out = vglMalloc(strlen(input) + 1);
-	glsl_preprocess("full", input, out);
+	char *out = glsl_preprocess("full", input);
 	vgl_free(input);
 #ifdef DEBUG_GLSL_PREPROCESSOR
 	vgl_log("%s:%d %s: GLSL preprocessor output:\n\n%s\n\n", __FILE__, __LINE__, __func__, out);

--- a/source/utils/glsl_utils.c
+++ b/source/utils/glsl_utils.c
@@ -1086,7 +1086,7 @@ void glsl_translator_process(shader *s) {
 	vgl_log("%s:%d %s: GLSL translation input:\n\n%s\n\n", __FILE__, __LINE__, __func__, input);
 #endif
 
-	char *out = vglMalloc(strlen(input));
+	char *out = vglMalloc(strlen(input) + 1);
 	glsl_preprocess("full", input, out);
 	vgl_free(input);
 #ifdef DEBUG_GLSL_PREPROCESSOR
@@ -1308,10 +1308,11 @@ void glsl_translator_process(shader *s) {
 	// Manually handle global variables, adding "static" to them
 	char *dst2 = vglMalloc(strlen(dst) + MEM_ENLARGER_SIZE); // FIXME: This is just an estimation, check if 1MB is enough/too big
 	glsl_handle_globals(dst, dst2, preamble_size);
+	size_t dst_len = strlen(dst);
 	vgl_free(dst);
 #ifdef HAVE_GLSL_UBOS
 	// Manually handle ubos
-	dst = vglMalloc(strlen(dst) + MEM_ENLARGER_SIZE); // FIXME: This is just an estimation, check if 1MB is enough/too big
+	dst = vglMalloc(dst_len + MEM_ENLARGER_SIZE); // FIXME: This is just an estimation, check if 1MB is enough/too big
 	glsl_handle_ubos(dst2, dst, preamble_size);
 	vgl_free(dst2);	
 	dst2 = dst;

--- a/source/utils/mem_utils.c
+++ b/source/utils/mem_utils.c
@@ -660,7 +660,7 @@ size_t vgl_malloc_usable_size(void *ptr) {
 #ifdef HAVE_CUSTOM_HEAP
 	tm_block_t **hdr = (tm_block_t **)((uintptr_t)ptr - 4);
 	tm_block_t *block = *hdr;
-	return block->size - 4;
+	return block->size - 8; // 4b header + 4b footer
 #else
 	return sceClibMspaceMallocUsableSize(ptr);
 #endif

--- a/source/utils/mem_utils.c
+++ b/source/utils/mem_utils.c
@@ -660,7 +660,7 @@ size_t vgl_malloc_usable_size(void *ptr) {
 #ifdef HAVE_CUSTOM_HEAP
 	tm_block_t **hdr = (tm_block_t **)((uintptr_t)ptr - 4);
 	tm_block_t *block = *hdr;
-	return block->size - 8; // 4b header + 4b footer
+	return block->size - 4;
 #else
 	return sceClibMspaceMallocUsableSize(ptr);
 #endif

--- a/source/utils/preprocessor/preprocessor.cpp
+++ b/source/utils/preprocessor/preprocessor.cpp
@@ -16,6 +16,8 @@
 #include "const.h"
 #include "expression.h"
 
+#include <vitaGL.h>
+
 using namespace std;
 
 namespace preprocessor
@@ -2145,4 +2147,5 @@ char * glsl_preprocess(char *mode, const char *infile) {
 	char *output = (char *)vglMalloc(out.size() + 1);
 	memcpy(output, out.c_str(), out.size() + 1);
 	return output;
+}
 }

--- a/source/utils/preprocessor/preprocessor.cpp
+++ b/source/utils/preprocessor/preprocessor.cpp
@@ -2135,13 +2135,14 @@ string preprocess(string mode, string infile, string outfile, list<string> defin
 }
 
 extern "C" {
-void glsl_preprocess(char *mode, const char *infile, char *output) {
+char * glsl_preprocess(char *mode, const char *infile) {
 	std::list<std::string> dummy;
 	std::list<std::string> defines;
 	defines.push_back("#define GL_ES 1");
 	defines.push_back("#define VITAGL");
 	std::map<std::string, std::string> hasCppAttributeMap;
 	std::string out = preprocessor::preprocess(mode, infile, "", defines, dummy, dummy, dummy, hasCppAttributeMap, false);
-	strcpy(output, out.c_str());
-}
+	char *output = (char *)vglMalloc(out.size() + 1);
+	memcpy(output, out.c_str(), out.size() + 1);
+	return output;
 }

--- a/source/utils/preprocessor/preprocessor_c.h
+++ b/source/utils/preprocessor/preprocessor_c.h
@@ -1,1 +1,1 @@
-void glsl_preprocess(char *mode, const char *fname, char *output);
+char * glsl_preprocess(char *mode, const char *fname);


### PR DESCRIPTION
Walked through the usages of strcpy and alike and ran static analysis.

Findings / fixes:
- Fixed a bunch of potentially overflowing strcpys in custom_shaders that can happen in case of really long handles which are technically allowed.
- Guarded against bufSize == 0 in glGetActiveAttrib and glGetActiveUniform, which is technically legal again even though shouldn't happen.
- Fixed what looks like a typo in glGetActiveUniform (name vs pname).
- Investigated custom heap implementation and found that the reported vgl_malloc_usable_size doesn't acoount for the block footer and could potentially lead to overwriting the footer and messing things up.
- Most importantly: found potentially very harmful string overflow when using preprocessor. Initially found that before calling preprocessor, `char *out = vglMalloc(strlen(input));` should have had `+1` in there for the null-terminator, but after thinking longer realized that in isolated cases preprocessor can end up writing the output WAY longer than what we allocate, so moved the allocation inside it instead.
- Finally, found a little use-after-free in glsl_utils.c.