### PR TITLE
Add source directory to include path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CC      = $(PREFIX)-gcc
 CXX     = $(PREFIX)-g++
 AR      = $(PREFIX)-gcc-ar
 CFLAGS  = -g -Wl,-q -O3 -ffast-math -mtune=cortex-a9 -mfpu=neon -Wno-incompatible-pointer-types -Wno-stringop-overflow -mfp16-format=ieee \
-	-DVGL_GIT_HASH='"$(shell git rev-parse --short HEAD)"'
+	-DVGL_GIT_HASH='"$(shell git rev-parse --short HEAD)"' -Isource
 ASFLAGS = $(CFLAGS)
 
 ifeq ($(SOFTFP_ABI),1)


### PR DESCRIPTION
Building vitaGL without vitaGL already installed triggers this error:
```
source/utils/preprocessor/preprocessor.cpp:19:10: fatal error: vitaGL.h: No such file or directory
   19 | #include <vitaGL.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [<builtin>: source/utils/preprocessor/preprocessor.o] Error 1
make: *** Waiting for unfinished jobs....
```
https://github.com/vitasdk/packages/actions/runs/30365923817/job/90303559098#step:7:96

This PR adds the `source` directory to include paths so all source files can now use `#include <vitaGL.h>` without issue